### PR TITLE
Support custom rule

### DIFF
--- a/src/Validation/Rule.php
+++ b/src/Validation/Rule.php
@@ -18,6 +18,7 @@ final class Rule
     public const RULE_SOMETIMES = "Sometimes";
     public const RULE_ARRAY = "Array";
     public const RULE_NUMERIC = "Numeric";
+    public const RULE_PHPSTANTYPE = "PHPStanType";
 
     public const RULES = [
         self::RULE_ACCEPTED_IF => self::RULE_ACCEPTED_IF,

--- a/src/Validation/RuleTreeNode.php
+++ b/src/Validation/RuleTreeNode.php
@@ -85,6 +85,8 @@ final class RuleTreeNode implements IteratorAggregate, \Countable
 
                 Rule::RULE_ARRAY => $this->isArray = true,
 
+                Rule::RULE_PHPSTANTYPE => (unserialize($rule->getParameters()[0])->isNull()->no() === true ? $this->nullable = $this->optional = false : $this->nullable = true),
+
                 default => null,
             };
             $this->rules[] = $rule;

--- a/src/Validation/TypeResolver.php
+++ b/src/Validation/TypeResolver.php
@@ -175,6 +175,8 @@ final class TypeResolver
 
             "In" => $this->resolveTypeIn($rule),
 
+            "PHPStanType" => unserialize($rule->getParameters()[0]),
+
             default => $this->resolveDefault($rule),
         };
     }


### PR DESCRIPTION
It will use `@phpstan-assert`

Exemple usage 

```php
class TrueArray implements \Illuminate\Contracts\Validation\ValidationRule
{
    public const string IDENTIFIER = 'validation.array';

    /**
     * Indicates whether the rule should be implicit.
     */
    public bool $implicit = true;

    /**
     * Run the validation rule.
     *
     * @param  string  $attribute
     * @param  mixed  $value
     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
     * @return void
     * @phpstan-assert array $value
     */
    public function validate(string $attribute, mixed $value, \Closure $fail): void
    {
        if (!is_array($value)) {
            $fail(static::IDENTIFIER)->translate();
        }
    }
}
```